### PR TITLE
Fix bug: only 4 bytes is copied back

### DIFF
--- a/CUDA/src/DRACC_CUDA_004_wrong_order_yes.cu
+++ b/CUDA/src/DRACC_CUDA_004_wrong_order_yes.cu
@@ -78,7 +78,7 @@ int main(){
     cudaErrorCheck( cudaDeviceSynchronize());
     
     // Copying the counter variable from the device to the host
-    cudaErrorCheck( cudaMemcpy(countervar,d_count,sizeof(int),cudaMemcpyDeviceToHost));
+    cudaErrorCheck( cudaMemcpy(countervar,d_count,B*T*sizeof(int),cudaMemcpyDeviceToHost));
     
     // Verifying result
     check();

--- a/CUDA/src/DRACC_CUDA_005_wrong_order_Inter_yes.cu
+++ b/CUDA/src/DRACC_CUDA_005_wrong_order_Inter_yes.cu
@@ -78,7 +78,7 @@ int main(){
     cudaErrorCheck( cudaDeviceSynchronize());
     
     // Copying the counter variable from the device to the host
-    cudaErrorCheck( cudaMemcpy(countervar,d_count,sizeof(int),cudaMemcpyDeviceToHost));
+    cudaErrorCheck( cudaMemcpy(countervar,d_count,B*T*sizeof(int),cudaMemcpyDeviceToHost));
     
     // Verifying result
     check();

--- a/CUDA/src/DRACC_CUDA_006_wrong_order_Intra_yes.cu
+++ b/CUDA/src/DRACC_CUDA_006_wrong_order_Intra_yes.cu
@@ -79,7 +79,7 @@ int main(){
     cudaErrorCheck( cudaDeviceSynchronize());
     
     // Copying the counter variable from the device to the host
-    cudaErrorCheck( cudaMemcpy(countervar,d_count,sizeof(int),cudaMemcpyDeviceToHost));
+    cudaErrorCheck( cudaMemcpy(countervar,d_count,B*T*sizeof(int),cudaMemcpyDeviceToHost));
     
     // Verifying result
     check();


### PR DESCRIPTION
The count of cudaMemcpy() from device to host is incorrect.